### PR TITLE
Remove email code

### DIFF
--- a/api/notifications.py
+++ b/api/notifications.py
@@ -1,37 +1,53 @@
-from django.core.mail import EmailMultiAlternatives
+import requests
 from django.template.loader import render_to_string
 from django.utils.timezone import localtime
 from django.conf import settings
 
+MAILGUN_API_KEY = settings.MAILGUN_API_KEY
+MAILGUN_DOMAIN = settings.MAILGUN_DOMAIN
+MAILGUN_SENDER = settings.MAILGUN_SENDER
+
+
+def mailgun_send(to, subject, html):
+    """
+    Send an email via Mailgun HTTP API.
+    """
+    if not to:
+        return
+
+    try:
+        requests.post(
+            f"https://api.mailgun.net/v3/{MAILGUN_DOMAIN}/messages",
+            auth=("api", MAILGUN_API_KEY),
+            data={
+                "from": MAILGUN_SENDER,
+                "to": [to],
+                "subject": subject,
+                "html": html,
+            },
+            timeout=10,
+        )
+    except Exception:
+        # Silent fail — prevents crashing the booking flow
+        pass
+
 
 def send_booking_confirmation_email(appt):
-    """Send HTML booking confirmation email."""
-
-    to = appt.contact_email or None
+    """Send the standard appointment confirmation email."""
+    to = appt.contact_email or (appt.user.email if appt.user else None)
     if not to:
         return
 
     dt_local = localtime(appt.datetime).strftime("%B %d, %Y at %I:%M %p")
 
-    context = {
+    html = render_to_string("booking_confirmation.html", {
         "name": appt.contact_name or "there",
         "style_name": appt.style.name,
         "datetime": dt_local,
-    }
+    })
 
-    subject = f"Booking Confirmed — {appt.style.name}"
-
-    try:
-        html_body = render_to_string("booking_confirmation.html", context)
-
-        msg = EmailMultiAlternatives(
-            subject=subject,
-            body="",
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            to=[to],
-        )
-        msg.attach_alternative(html_body, "text/html")
-        msg.send(fail_silently=True)
-
-    except Exception as e:
-        raise
+    mailgun_send(
+        to,
+        f"Booking Confirmed — {appt.style.name}",
+        html
+    )

--- a/api/views.py
+++ b/api/views.py
@@ -111,10 +111,10 @@ class AppointmentViewSet(viewsets.ModelViewSet):
             raise err
 
         #Send email confirmation
-        try:
-            send_booking_confirmation_email(appt)
-        except Exception:
-            pass
+        #try:
+            #send_booking_confirmation_email(appt)
+        #except Exception:
+        #   pass
 
    # ---------------- TAKEN SLOTS (LOCAL TIME, FULL DETAILS) ----------------
     @action(

--- a/config/settings.py
+++ b/config/settings.py
@@ -160,17 +160,10 @@ CSRF_TRUSTED_ORIGINS = [
 
 CORS_ALLOW_CREDENTIALS = True
 
-# --- Email (production via Gmail SMTP) ---
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = "smtp.gmail.com"
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
-
-EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
-EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
-
-DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
-
+#Handle emails
+MAILGUN_API_KEY = os.getenv("MAILGUN_API_KEY")
+MAILGUN_DOMAIN = os.getenv("MAILGUN_DOMAIN")
+MAILGUN_SENDER = os.getenv("MAILGUN_SENDER")
 
 # --- Stripe / Frontend ---
 # Read ONLY from environment variables.

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ gunicorn
 whitenoise[brotli]
 stripe
 pytz
+requests


### PR DESCRIPTION
SMTP is not usable through render (our backend deployment service) free tiers for email sending services such as mailgun require paid subscriptions/domains to send emails to anyone....I'm leaving the code here for mailgun because with a subscription this could be nice in the project.